### PR TITLE
Add .gitattributes to make source types properly.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+**/c/* gitlab-language=c linguist-language=c
+**/h/* gitlab-language=c linguist-language=c
+**/s/* gitlab-language=armasm linguist-language=assembly
+*,fe1 gitlab-language=make linguist-language=makefile
+VersionNum gitlab-language=c linguist-language=c

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,16 @@
 Artifacts/
-oz/
-oz32/
-od/
-o32d/
-ozd/
-oz32d/
-o/
-o32/
-rm/
-rm32/
-aif/
-aif32/
+**/aif/*
+**/aif32/*
+**/o/*
+**/o32/*
+**/o32d/*
+**/od/*
+**/oz/*
+**/oz32/*
+**/oz32d/*
+**/ozd/*
+**/rm/*
+**/rm32/*
 
 # CMHG header file is auto-generated
 SourceCode/LanMan/h/omniheader


### PR DESCRIPTION
For GitLab and GitHub there are markers to add into the .gitattributes
file to show what language (and syntax) should be used for those files.
The attributes here should allow us to colour the text properly in
both GitLab and GitHub's rendering of the source.